### PR TITLE
[FIX] Corrección en modelo de Empleado

### DIFF
--- a/odoo_nelson/models/configuration/employee.py
+++ b/odoo_nelson/models/configuration/employee.py
@@ -8,11 +8,10 @@ class NelsonEmployee(models.Model):
     _name = 'nelson.employee'
     _description = 'Employee'
     _inherit = ['mail.thread', 'mail.activity.mixin']
-    _rec_name = 'name'
-    _order = 'name'
+    _rec_name = 'id'
+    _order = 'id asc'
 
     employee_id = fields.Many2one(HR_EMPLOYEE_MODEL, string='Employee ID', required=True, help='Employee ID')
-    name = fields.Char(string='Name', related="employee_id.name", store=True, help='Name')
     employee_category_id = fields.Many2one('nelson.employee.category', string='Employee Category', required=True, help='Employee Category')
     department_id = fields.Many2one('nelson.department', string='Department', required=True, help='Department')
     active = fields.Boolean(string='Active', default=True, help='Active')


### PR DESCRIPTION
This pull request includes changes to the `odoo_nelson/models/configuration/employee.py` file to modify the `NelsonEmployee` model. The changes focus on updating the primary display and ordering fields of the model.

Key changes include:

* Changed `_rec_name` from `name` to `id` to use the employee ID as the primary display field.
* Updated `_order` from `name` to `id asc` to order the records by employee ID in ascending order.
* Removed the `name` field, which was previously a related field to `employee_id.name`.Se corrige el modelo de Empleado personalizado